### PR TITLE
Add grcov configuration

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,11 @@
+branch: true
+ignore-not-existing: true
+llvm: true
+filter: covered
+output-type: lcov
+output-file: ./lcov.info
+prefix-dir: /home/user/build/
+ignore:
+  - "/*"
+  - "C:/*"
+  - "../*"

--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,7 +1,6 @@
 branch: true
 ignore-not-existing: true
 llvm: true
-filter: covered
 output-type: lcov
 output-file: ./lcov.info
 prefix-dir: /home/user/build/

--- a/.github/workflows/grcov.yml
+++ b/.github/workflows/grcov.yml
@@ -4,7 +4,6 @@ name: Code coverage with grcov
 
 jobs:
   grcov:
-    continue-on-error: true
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/grcov.yml
+++ b/.github/workflows/grcov.yml
@@ -4,6 +4,7 @@ name: Code coverage with grcov
 
 jobs:
   grcov:
+    continue-on-error: true
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Coveralls/grcov without a configuration seems to include coverage of library files,
which we can't control. So add a configuration file based on the example from the
GitHub Action repo, with paths to ignore.

This should improve the server's code coverage score.